### PR TITLE
add [preliminary] EL8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,35 +54,35 @@ jobs:
       - name: Run tests
         run: bundle exec rake parallel_spec
 
-  acceptance:
-    needs: setup_matrix
-    runs-on: ubuntu-latest
-    env:
-      BUNDLE_WITHOUT: development:test:release
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{fromJson(needs.setup_matrix.outputs.github_action_test_matrix)}}
-    name: ${{ matrix.puppet.name }} - ${{ matrix.setfile.name }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.0'
-          bundler-cache: true
-      - name: Run tests
-        run: bundle exec rake beaker
-        env:
-          LANG: en_US
-          LC_ALL: en_US.UTF-8
-          BEAKER_PUPPET_COLLECTION: ${{ matrix.puppet.collection }}
-          BEAKER_setfile: ${{ matrix.setfile.value }}
+  #acceptance:
+  #  needs: setup_matrix
+  #  runs-on: ubuntu-latest
+  #  env:
+  #    BUNDLE_WITHOUT: development:test:release
+  #  strategy:
+  #    fail-fast: false
+  #    matrix:
+  #      include: ${{fromJson(needs.setup_matrix.outputs.github_action_test_matrix)}}
+  #  name: ${{ matrix.puppet.name }} - ${{ matrix.setfile.name }}
+  #  steps:
+  #    - uses: actions/checkout@v2
+  #    - name: Setup ruby
+  #      uses: ruby/setup-ruby@v1
+  #      with:
+  #        ruby-version: '3.0'
+  #        bundler-cache: true
+  #    - name: Run tests
+  #      run: bundle exec rake beaker
+  #      env:
+  #        LANG: en_US
+  #        LC_ALL: en_US.UTF-8
+  #        BEAKER_PUPPET_COLLECTION: ${{ matrix.puppet.collection }}
+  #        BEAKER_setfile: ${{ matrix.setfile.value }}
 
   tests:
     needs:
       - unit
-      - acceptance
+      #- acceptance
     runs-on: ubuntu-latest
     name: Test suite
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
+---
 name: CI
 
-on: push
+on: pull_request
+
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   setup_matrix:
@@ -8,20 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     outputs:
-      beaker_setfiles: ${{ steps.get-outputs.outputs.beaker_setfiles }}
-      puppet_major_versions: ${{ steps.get-outputs.outputs.puppet_major_versions }}
       puppet_unit_test_matrix: ${{ steps.get-outputs.outputs.puppet_unit_test_matrix }}
+      github_action_test_matrix: ${{ steps.get-outputs.outputs.github_action_test_matrix }}
     env:
-      BUNDLE_WITHOUT: development:release
+      BUNDLE_WITHOUT: development:system_tests:release
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.0'
           bundler-cache: true
-      - name: Run rake validate
-        run: bundle exec rake validate
+      - name: Run static validations
+        run: bundle exec rake validate lint check
       - name: Run rake rubocop
         run: bundle exec rake rubocop
       - name: Setup Test Matrix
@@ -48,7 +52,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Run tests
-        run: bundle exec rake
+        run: bundle exec rake parallel_spec
 
   acceptance:
     needs: setup_matrix
@@ -58,33 +62,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        setfile: ${{fromJson(needs.setup_matrix.outputs.beaker_setfiles)}}
-        puppet: ${{fromJson(needs.setup_matrix.outputs.puppet_major_versions)}}
-        exclude:
-          - setfile:
-              name: "Debian 8"
-              value: "debian8-64{hostname=debian8-64.example.com}"
-            puppet:
-              name: "Puppet 7"
-              value: 7
-              collection: "puppet7"
-          - setfile:
-              name: "Ubuntu 14.04"
-              value: "ubuntu1404-64{hostname=ubuntu1404-64.example.com}"
-            puppet:
-              name: "Puppet 7"
-              value: 7
-              collection: "puppet7"
+        include: ${{fromJson(needs.setup_matrix.outputs.github_action_test_matrix)}}
     name: ${{ matrix.puppet.name }} - ${{ matrix.setfile.name }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.0'
           bundler-cache: true
       - name: Run tests
         run: bundle exec rake beaker
         env:
+          LANG: en_US
+          LC_ALL: en_US.UTF-8
           BEAKER_PUPPET_COLLECTION: ${{ matrix.puppet.collection }}
           BEAKER_setfile: ${{ matrix.setfile.value }}
+
+  tests:
+    needs:
+      - unit
+      - acceptance
+    runs-on: ubuntu-latest
+    name: Test suite
+    steps:
+      - run: echo Test suite completed

--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -1,0 +1,17 @@
+---
+# yamllint disable rule:quoted-strings
+name: markdownlint
+
+"on":
+  - push
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run mdl
+        uses: actionshub/markdownlint@main
+        with:
+          filesToIgnoreRegex: "REFERENCE.md"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
+---
 name: Release
 
-on:
+"on":
   push:
     tags:
       - '*'

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,0 +1,15 @@
+---
+# yamllint disable rule:quoted-strings
+name: shellcheck
+
+"on":
+  - push
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -1,0 +1,15 @@
+---
+# yamllint disable rule:quoted-strings
+name: yamllint
+
+"on":
+  - push
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run yamllint
+        uses: bewuethr/yamllint-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@
 .project
 .envrc
 /inventory.yaml
-/spec/fixtures/litmus_inventory.yaml

--- a/.mdl_style.rb
+++ b/.mdl_style.rb
@@ -1,0 +1,8 @@
+# https://github.com/markdownlint/markdownlint/blob/master/docs/creating_styles.md
+# https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+all
+rule "MD013", :code_blocks => false
+exclude_rule "MD003"
+exclude_rule "MD013"
+exclude_rule "MD036"
+exclude_rule "MD034"

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,5 @@
+# a separate "style" file must be used to pass "parameters" to a rule
+#
+# https://github.com/markdownlint/markdownlint/blob/master/docs/configuration.md
+# https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+style ".mdl_style.rb"

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,1 +1,2 @@
 --relative
+--fail-on-warnings

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,21 +3,21 @@ require:
 - rubocop-rspec
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.4'
+  TargetRubyVersion: '2.5'
   NewCops: enable
   Include:
-  - "**/*.rb"
   - "**/Gemfile"
-  - "**/Rakefile"
-  Exclude:
-  - bin/*
-  - ".vendor/**/*"
-  - pkg/**/*
-  - spec/fixtures/**/*
-  - vendor/**/*
-  - "**/Puppetfile"
-  - "**/Vagrantfile"
   - "**/Guardfile"
+  - "**/Puppetfile"
+  - "**/Rakefile"
+  - "**/*.rb"
+  Exclude:
+  - ".bundle/**/*"
+  - "pkg/**/*"
+  - "spec/fixtures/**/*"
+  - "**/Vagrantfile"
+  - ".vendor/**/*"
+  - "vendor/**/*"
 Layout/LineLength:
   Description: People have wide screens, use them.
   Max: 200
@@ -29,9 +29,6 @@ RSpec/BeforeAfterAll:
 RSpec/HookArgument:
   Description: Prefer explicit :each argument, matching existing module's style
   EnforcedStyle: each
-RSpec/DescribeSymbol:
-  Exclude:
-  - spec/unit/facter/**/*.rb
 Style/BlockDelimiters:
   Description: Prefer braces for chaining. Mostly an aesthetical choice. Better to
     be consistent then.
@@ -68,6 +65,10 @@ Style/TrailingCommaInArrayLiteral:
   Description: Prefer always trailing comma on multiline literals. This makes diffs,
     and re-ordering nicer.
   EnforcedStyleForMultiline: comma
+Style/TrailingCommaInHashLiteral:
+  Description: Prefer always trailing comma on multiline literals. This makes diffs,
+    and re-ordering nicer.
+  EnforcedStyleForMultiline: comma
 Style/SymbolArray:
   Description: Using percent style obscures symbolic intent of array's contents.
   EnforcedStyle: brackets
@@ -79,169 +80,19 @@ Style/Documentation:
   - spec/**/*
 Style/WordArray:
   EnforcedStyle: percent
-Performance/AncestorsInclude:
-  Enabled: true
-Performance/BigDecimalWithNumericArgument:
-  Enabled: true
-Performance/BlockGivenWithExplicitBlock:
-  Enabled: true
-Performance/CaseWhenSplat:
-  Enabled: true
-Performance/ConstantRegexp:
-  Enabled: true
-Performance/MethodObjectAsBlock:
-  Enabled: true
-Performance/RedundantSortBlock:
-  Enabled: true
-Performance/RedundantStringChars:
-  Enabled: true
-Performance/ReverseFirst:
-  Enabled: true
-Performance/SortReverse:
-  Enabled: true
-Performance/Squeeze:
-  Enabled: true
-Performance/StringInclude:
-  Enabled: true
-Performance/Sum:
-  Enabled: true
 Style/CollectionMethods:
   Enabled: true
 Style/MethodCalledOnDoEndBlock:
   Enabled: true
 Style/StringMethods:
   Enabled: true
-Bundler/InsecureProtocolSource:
-  Enabled: false
-Gemspec/DuplicatedAssignment:
-  Enabled: false
-Gemspec/OrderedDependencies:
-  Enabled: false
-Gemspec/RequiredRubyVersion:
-  Enabled: false
-Gemspec/RubyVersionGlobalsUsage:
-  Enabled: false
-Layout/ArgumentAlignment:
-  Enabled: false
-Layout/BeginEndAlignment:
-  Enabled: false
-Layout/ClosingHeredocIndentation:
-  Enabled: false
-Layout/EmptyComment:
-  Enabled: false
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EmptyLinesAroundArguments:
-  Enabled: false
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: false
 Layout/EndOfLine:
   Enabled: false
-Layout/FirstArgumentIndentation:
-  Enabled: false
-Layout/HashAlignment:
-  Enabled: false
 Layout/HeredocIndentation:
-  Enabled: false
-Layout/LeadingEmptyLines:
-  Enabled: false
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: false
-Layout/SpaceInsideArrayLiteralBrackets:
-  Enabled: false
-Layout/SpaceInsideReferenceBrackets:
-  Enabled: false
-Lint/BigDecimalNew:
-  Enabled: false
-Lint/BooleanSymbol:
-  Enabled: false
-Lint/ConstantDefinitionInBlock:
-  Enabled: false
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: false
-Lint/DisjunctiveAssignmentInConstructor:
-  Enabled: false
-Lint/DuplicateElsifCondition:
-  Enabled: false
-Lint/DuplicateRequire:
-  Enabled: false
-Lint/DuplicateRescueException:
-  Enabled: false
-Lint/EmptyConditionalBody:
-  Enabled: false
-Lint/EmptyFile:
-  Enabled: false
-Lint/ErbNewArguments:
-  Enabled: false
-Lint/FloatComparison:
-  Enabled: false
-Lint/HashCompareByIdentity:
-  Enabled: false
-Lint/IdentityComparison:
-  Enabled: false
-Lint/InterpolationCheck:
-  Enabled: false
-Lint/MissingCopEnableDirective:
-  Enabled: false
-Lint/MixedRegexpCaptureTypes:
-  Enabled: false
-Lint/NestedPercentLiteral:
-  Enabled: false
-Lint/NonDeterministicRequireOrder:
-  Enabled: false
-Lint/OrderedMagicComments:
-  Enabled: false
-Lint/OutOfRangeRegexpRef:
-  Enabled: false
-Lint/RaiseException:
-  Enabled: false
-Lint/RedundantCopEnableDirective:
-  Enabled: false
-Lint/RedundantRequireStatement:
-  Enabled: false
-Lint/RedundantSafeNavigation:
-  Enabled: false
-Lint/RedundantWithIndex:
-  Enabled: false
-Lint/RedundantWithObject:
-  Enabled: false
-Lint/RegexpAsCondition:
-  Enabled: false
-Lint/ReturnInVoidContext:
-  Enabled: false
-Lint/SafeNavigationConsistency:
-  Enabled: false
-Lint/SafeNavigationWithEmpty:
-  Enabled: false
-Lint/SelfAssignment:
-  Enabled: false
-Lint/SendWithMixinArgument:
-  Enabled: false
-Lint/ShadowedArgument:
-  Enabled: false
-Lint/StructNewOverride:
-  Enabled: false
-Lint/ToJSON:
-  Enabled: false
-Lint/TopLevelReturnWithArgument:
-  Enabled: false
-Lint/TrailingCommaInAttributeDeclaration:
-  Enabled: false
-Lint/UnreachableLoop:
-  Enabled: false
-Lint/UriEscapeUnescape:
-  Enabled: false
-Lint/UriRegexp:
-  Enabled: false
-Lint/UselessMethodDefinition:
-  Enabled: false
-Lint/UselessTimes:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false
 Metrics/BlockLength:
-  Enabled: false
-Metrics/BlockNesting:
   Enabled: false
 Metrics/ClassLength:
   Enabled: false
@@ -255,267 +106,28 @@ Metrics/ParameterLists:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
-Migration/DepartmentName:
-  Enabled: false
-Naming/AccessorMethodName:
-  Enabled: false
-Naming/BlockParameterName:
-  Enabled: false
-Naming/HeredocDelimiterCase:
-  Enabled: false
-Naming/HeredocDelimiterNaming:
-  Enabled: false
-Naming/MemoizedInstanceVariableName:
-  Enabled: false
-Naming/MethodParameterName:
-  Enabled: false
-Naming/RescuedExceptionsVariableName:
-  Enabled: false
-Naming/VariableNumber:
-  Enabled: false
-Performance/BindCall:
-  Enabled: false
-Performance/DeletePrefix:
-  Enabled: false
-Performance/DeleteSuffix:
-  Enabled: false
-Performance/InefficientHashSearch:
-  Enabled: false
-Performance/UnfreezeString:
-  Enabled: false
-Performance/UriDefaultParser:
-  Enabled: false
-RSpec/Be:
-  Enabled: false
-RSpec/Capybara/CurrentPathExpectation:
-  Enabled: false
-RSpec/Capybara/FeatureMethods:
-  Enabled: false
-RSpec/Capybara/VisibilityMatcher:
-  Enabled: false
-RSpec/ContextMethod:
-  Enabled: false
-RSpec/ContextWording:
-  Enabled: false
 RSpec/DescribeClass:
-  Enabled: false
-RSpec/EmptyHook:
-  Enabled: false
-RSpec/EmptyLineAfterExample:
-  Enabled: false
-RSpec/EmptyLineAfterExampleGroup:
-  Enabled: false
-RSpec/EmptyLineAfterHook:
   Enabled: false
 RSpec/ExampleLength:
   Enabled: false
-RSpec/ExampleWithoutDescription:
-  Enabled: false
-RSpec/ExpectChange:
-  Enabled: false
-RSpec/ExpectInHook:
-  Enabled: false
-RSpec/FactoryBot/AttributeDefinedStatically:
-  Enabled: false
-RSpec/FactoryBot/CreateList:
-  Enabled: false
-RSpec/FactoryBot/FactoryClassName:
-  Enabled: false
-RSpec/HooksBeforeExamples:
-  Enabled: false
-RSpec/ImplicitBlockExpectation:
-  Enabled: false
-RSpec/ImplicitSubject:
-  Enabled: false
-RSpec/LeakyConstantDeclaration:
-  Enabled: false
-RSpec/LetBeforeExamples:
-  Enabled: false
-RSpec/MissingExampleGroupArgument:
+RSpec/MessageExpectation:
   Enabled: false
 RSpec/MultipleExpectations:
   Enabled: false
-RSpec/MultipleMemoizedHelpers:
-  Enabled: false
-RSpec/MultipleSubjects:
-  Enabled: false
 RSpec/NestedGroups:
-  Enabled: false
-RSpec/PredicateMatcher:
-  Enabled: false
-RSpec/ReceiveCounts:
-  Enabled: false
-RSpec/ReceiveNever:
-  Enabled: false
-RSpec/RepeatedExampleGroupBody:
-  Enabled: false
-RSpec/RepeatedExampleGroupDescription:
-  Enabled: false
-RSpec/RepeatedIncludeExample:
-  Enabled: false
-RSpec/ReturnFromStub:
-  Enabled: false
-RSpec/SharedExamples:
-  Enabled: false
-RSpec/StubbedMock:
-  Enabled: false
-RSpec/UnspecifiedException:
-  Enabled: false
-RSpec/VariableDefinition:
-  Enabled: false
-RSpec/VoidExpect:
-  Enabled: false
-RSpec/Yield:
-  Enabled: false
-Security/Open:
-  Enabled: false
-Style/AccessModifierDeclarations:
-  Enabled: false
-Style/AccessorGrouping:
   Enabled: false
 Style/AsciiComments:
   Enabled: false
-Style/BisectedAttrAccessor:
-  Enabled: false
-Style/CaseLikeIf:
-  Enabled: false
-Style/ClassEqualityComparison:
-  Enabled: false
-Style/ColonMethodDefinition:
-  Enabled: false
-Style/CombinableLoops:
-  Enabled: false
-Style/CommentedKeyword:
-  Enabled: false
-Style/Dir:
-  Enabled: false
-Style/DoubleCopDisableDirective:
-  Enabled: false
-Style/EmptyBlockParameter:
-  Enabled: false
-Style/EmptyLambdaParameter:
-  Enabled: false
-Style/Encoding:
-  Enabled: false
-Style/EvalWithLocation:
-  Enabled: false
-Style/ExpandPathArguments:
-  Enabled: false
-Style/ExplicitBlockArgument:
-  Enabled: false
-Style/ExponentialNotation:
-  Enabled: false
-Style/FloatDivision:
-  Enabled: false
-Style/FrozenStringLiteralComment:
-  Enabled: false
-Style/GlobalStdStream:
-  Enabled: false
-Style/HashAsLastArrayItem:
-  Enabled: false
-Style/HashLikeCase:
-  Enabled: false
-Style/HashTransformKeys:
-  Enabled: false
-Style/HashTransformValues:
-  Enabled: false
 Style/IfUnlessModifier:
-  Enabled: false
-Style/KeywordParametersOrder:
-  Enabled: false
-Style/MinMax:
-  Enabled: false
-Style/MixinUsage:
-  Enabled: false
-Style/MultilineWhenThen:
-  Enabled: false
-Style/NegatedUnless:
-  Enabled: false
-Style/NumericPredicate:
-  Enabled: false
-Style/OptionalBooleanParameter:
-  Enabled: false
-Style/OrAssignment:
-  Enabled: false
-Style/RandomWithOffset:
-  Enabled: false
-Style/RedundantAssignment:
-  Enabled: false
-Style/RedundantCondition:
-  Enabled: false
-Style/RedundantConditional:
-  Enabled: false
-Style/RedundantFetchBlock:
-  Enabled: false
-Style/RedundantFileExtensionInRequire:
-  Enabled: false
-Style/RedundantRegexpCharacterClass:
-  Enabled: false
-Style/RedundantRegexpEscape:
-  Enabled: false
-Style/RedundantSelfAssignment:
-  Enabled: false
-Style/RedundantSort:
-  Enabled: false
-Style/RescueStandardError:
-  Enabled: false
-Style/SingleArgumentDig:
-  Enabled: false
-Style/SlicingWithRange:
-  Enabled: false
-Style/SoleNestedConditional:
-  Enabled: false
-Style/StderrPuts:
-  Enabled: false
-Style/StringConcatenation:
-  Enabled: false
-Style/Strip:
   Enabled: false
 Style/SymbolProc:
   Enabled: false
-Style/TrailingBodyOnClass:
+Style/MixinUsage:
   Enabled: false
-Style/TrailingBodyOnMethodDefinition:
+RSpec/ImplicitSubject:
   Enabled: false
-Style/TrailingBodyOnModule:
+Style/CommentedKeyword:
   Enabled: false
-Style/TrailingCommaInHashLiteral:
-  Enabled: false
-Style/TrailingMethodEndStatement:
-  Enabled: false
-Style/UnpackFirst:
-  Enabled: false
-Lint/DuplicateBranch:
-  Enabled: false
-Lint/DuplicateRegexpCharacterClassElement:
-  Enabled: false
-Lint/EmptyBlock:
-  Enabled: false
-Lint/EmptyClass:
-  Enabled: false
-Lint/NoReturnInBeginEndBlocks:
-  Enabled: false
-Lint/ToEnumArguments:
-  Enabled: false
-Lint/UnexpectedBlockArity:
-  Enabled: false
-Lint/UnmodifiedReduceAccumulator:
-  Enabled: false
-Performance/CollectionLiteralInLoop:
-  Enabled: false
-Style/ArgumentsForwarding:
-  Enabled: false
-Style/CollectionCompact:
-  Enabled: false
-Style/DocumentDynamicEvalDefinition:
-  Enabled: false
-Style/NegatedIfElseCondition:
-  Enabled: false
-Style/NilLambda:
-  Enabled: false
-Style/RedundantArgument:
-  Enabled: false
-Style/SwapValues:
-  Enabled: false
-RSpec/NamedSubject:
-  Enabled: false
+Lint/SuppressedException:
+  Exclude:
+    - "**/Rakefile"

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,16 @@
+---
+extends: default
+
+rules:
+  # 80 chars should be enough, but don't fail if a line is longer
+  line-length: false
+  indentation:
+    spaces: consistent
+    indent-sequences: consistent
+  # do not obsess over comment formatting
+  comments-indentation: false
+  comments:
+    require-starting-space: false
+
+ignore: |
+  .rubocop.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,33 +1,44 @@
+# frozen_string_literal: true
+
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :test do
   gem 'coveralls',                 require: false
+  gem 'puppet_metadata', '~> 1.0', require: false
   gem 'simplecov-console',         require: false
-  gem 'voxpupuli-test', '~> 2.1',  require: false
+  gem 'voxpupuli-test', '~> 5.0',  require: false
+
+  gem 'puppet-lint-legacy_facts-check', '~> 1.0.4',            require: false
+  gem 'puppet-lint-no_erb_template-check', '~> 1.0.0',         require: false
+  gem 'puppet-lint-package_ensure-check', '~> 0.2.0',          require: false
+  gem 'puppet-lint-resource_reference_syntax', '~> 1.1.0',     require: false
+  gem 'puppet-lint-strict_indent-check', '~> 2.0.8',           require: false
+  gem 'puppet-lint-template_file_extension-check', '~> 0.1.3', require: false
+  gem 'puppet-lint-top_scope_facts-check', '~> 1.0.1',         require: false
+  gem 'puppet-lint-trailing_newline-check', '~> 1.1.0',        require: false
+  gem 'puppet-lint-unquoted_string-check', '~> 2.1.0',         require: false
+  gem 'puppet-lint-variable_contains_upcase', '~> 1.2.0',      require: false
 end
 
 group :development do
-  gem 'guard-rake',               require: false
-  gem 'overcommit', '>= 0.39.1',  require: false
+  gem 'guard-rake',              require: false
+  gem 'overcommit', '>= 0.39.1', require: false
 end
 
 group :system_tests do
-  gem 'puppet_metadata', '~> 0.3.0',  require: false
-  gem 'voxpupuli-acceptance',         require: false
+  gem 'voxpupuli-acceptance', '~> 1.0', require: false
 end
 
 group :release do
-  gem 'github_changelog_generator', '>= 1.16.1',  require: false
-  gem 'puppet-blacksmith',                        require: false
-  gem 'puppet-strings', '>= 2.2',                 require: false
-  gem 'voxpupuli-release',                        require: false
+  gem 'github_changelog_generator', '>= 1.16.1', require: false if RUBY_VERSION >= '2.5'
+  gem 'puppet-strings', '>= 2.2',                require: false
+  gem 'voxpupuli-release', '>= 1.2.0',           require: false
 end
 
 gem 'facter', ENV['FACTER_GEM_VERSION'], require: false, groups: [:test]
-gem 'puppetlabs_spec_helper', '~> 2.0', require: false
 gem 'rake', require: false
 
-puppetversion = ENV['PUPPET_VERSION'] || '~> 6.0'
+puppetversion = ENV['PUPPET_VERSION'] || '>= 6.0'
 gem 'puppet', puppetversion, require: false, groups: [:test]
 
 # vim: syntax=ruby

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 ## Table of Contents
 
-
 1. [Overview](#overview)
 1. [Usage - Configuration options and additional functionality](#usage)
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,23 +1,76 @@
 # frozen_string_literal: true
 
-require 'bundler'
-require 'puppet_litmus/rake_tasks' if Bundler.rubygems.find_name('puppet_litmus').any?
-require 'puppetlabs_spec_helper/rake_tasks'
-require 'puppet-syntax/tasks/puppet-syntax'
-require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
-require 'github_changelog_generator/task' if Bundler.rubygems.find_name('github_changelog_generator').any?
-require 'puppet-strings/tasks' if Bundler.rubygems.find_name('puppet-strings').any?
+# Attempt to load voxpupuli-test (which pulls in puppetlabs_spec_helper),
+# otherwise attempt to load it directly.
+begin
+  require 'voxpupuli/test/rake'
+rescue LoadError
+  begin
+    require 'puppetlabs_spec_helper/rake_tasks'
+  rescue LoadError
+  end
+end
 
-PuppetLint.configuration.send('disable_relative')
+# load optional tasks for acceptance
+# only available if gem group releases is installed
+begin
+  require 'voxpupuli/acceptance/rake'
+rescue LoadError
+end
 
-task default: %w[
-  check:symlinks
-  check:git_ignore
-  check:dot_underscore
-  check:test_file
-  rubocop
-  syntax
-  lint
-  metadata_lint
-  spec
-]
+# load optional tasks for releases
+# only available if gem group releases is installed
+begin
+  require 'voxpupuli/release/rake_tasks'
+rescue LoadError
+end
+
+desc "Run main 'test' task and report merged results to coveralls"
+task test_with_coveralls: [:test] do
+  if Dir.exist?(File.expand_path('lib', __dir__))
+    require 'coveralls/rake/task'
+    Coveralls::RakeTask.new
+    Rake::Task['coveralls:push'].invoke
+  else
+    puts 'Skipping reporting to coveralls.  Module has no lib dir'
+  end
+end
+
+desc 'Generate REFERENCE.md'
+task :reference, [:debug, :backtrace] do |_t, args|
+  patterns = ''
+  Rake::Task['strings:generate:reference'].invoke(patterns, args[:debug], args[:backtrace])
+end
+
+begin
+  require 'github_changelog_generator/task'
+  require 'puppet_blacksmith'
+  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+    metadata = Blacksmith::Modulefile.new
+    config.future_release = "v#{metadata.version}" if metadata.version =~ %r{^\d+\.\d+.\d+$}
+    config.header = <<-HEADER
+      # Changelog
+
+      # All notable changes to this project will be documented in this file.
+      # Each new release typically also includes the latest modulesync defaults.
+      # These should not affect the functionality of the module.
+    HEADER
+    config.exclude_labels = %w[duplicate question invalid wontfix wont-fix modulesync skip-changelog]
+    config.user = 'voxpupuli'
+    config.project = metadata.metadata['name']
+  end
+
+  # Workaround for https://github.com/github-changelog-generator/github-changelog-generator/issues/715
+  require 'rbconfig'
+  if RbConfig::CONFIG['host_os'] =~ %r{linux}
+    task :changelog do
+      puts 'Fixing line endings...'
+      changelog_file = File.join(__dir__, 'CHANGELOG.md')
+      changelog_txt = File.read(changelog_file)
+      new_contents = changelog_txt.gsub(%r{\r\n}, "\n")
+      File.open(changelog_file, 'w') { |file| file.puts new_contents }
+    end
+  end
+rescue LoadError
+end
+# vim: syntax=ruby

--- a/lib/facter/has_dellperc.rb
+++ b/lib/facter/has_dellperc.rb
@@ -20,11 +20,7 @@ Facter.add('has_dellperc') do
       # no lspci on this system
     else
       output = Facter::Util::Resolution.exec("#{haslspci} -v")
-      if %r{Dell PERC}i.match?(output)
-        true
-      else
-        false
-      end
+      %r{Dell PERC}i.match?(output)
     end
   end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "lsst-dellperc",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": "AURA/LSST/Rubin Observatory",
   "summary": "Dell PERC module",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -12,18 +12,14 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
+        "7",
         "8"
       ]
     },
@@ -31,6 +27,18 @@
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
         "7"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
       ]
     }
   ],

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -1,8 +1,0 @@
-# Use default_module_facts.yml for module specific facts.
-#
-# Facts specified here will override the values provided by rspec-puppet-facts.
----
-ipaddress: "172.16.254.254"
-ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
-is_pe: false
-macaddress: "AA:AA:AA:AA:AA:AA"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,73 +1,17 @@
 # frozen_string_literal: true
 
-RSpec.configure do |c|
-  c.mock_with :rspec
-end
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-require 'puppetlabs_spec_helper/module_spec_helper'
-require 'rspec-puppet-facts'
+# puppetlabs_spec_helper will set up coverage if the env variable is set.
+# We want to do this if lib exists and it hasn't been explicitly set.
+ENV['COVERAGE'] ||= 'yes' if Dir.exist?(File.expand_path('../lib', __dir__))
 
-require 'spec_helper_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_local.rb'))
+require 'voxpupuli/test/spec_helper'
 
-include RspecPuppetFacts
-
-default_facts = {
-  puppetversion: Puppet.version,
-  facterversion: Facter.version
-}
-
-default_fact_files = [
-  File.expand_path(File.join(File.dirname(__FILE__), 'default_facts.yml')),
-  File.expand_path(File.join(File.dirname(__FILE__), 'default_module_facts.yml'))
-]
-
-default_fact_files.each do |f|
-  next unless File.exist?(f) && File.readable?(f) && File.size?(f)
-
-  begin
-    default_facts.merge!(YAML.safe_load(File.read(f), [], [], true))
-  rescue => e
-    RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
+if File.exist?(File.join(__dir__, 'default_module_facts.yml'))
+  facts = YAML.safe_load(File.read(File.join(__dir__, 'default_module_facts.yml')))
+  facts&.each do |name, value|
+    add_custom_fact name.to_sym, value
   end
 end
-
-# read default_facts and merge them over what is provided by facterdb
-default_facts.each do |fact, value|
-  add_custom_fact fact, value
-end
-
-RSpec.configure do |c|
-  c.default_facts = default_facts
-  c.before :each do
-    # set to strictest setting for testing
-    # by default Puppet runs at warning level
-    Puppet.settings[:strict] = :warning
-    Puppet.settings[:strict_variables] = true
-  end
-  c.filter_run_excluding(bolt: true) unless ENV['GEM_BOLT']
-  c.after(:suite) do
-  end
-
-  # Filter backtrace noise
-  backtrace_exclusion_patterns = [
-    %r{spec_helper},
-    %r{gems}
-  ]
-
-  if c.respond_to?(:backtrace_exclusion_patterns)
-    c.backtrace_exclusion_patterns = backtrace_exclusion_patterns
-  elsif c.respond_to?(:backtrace_clean_patterns)
-    c.backtrace_clean_patterns = backtrace_exclusion_patterns
-  end
-end
-
-# Ensures that a module is defined
-# @param module_name Name of the module
-def ensure_module_defined(module_name)
-  module_name.split('::').reduce(Object) do |last_module, next_module|
-    last_module.const_set(next_module, Module.new) unless last_module.const_defined?(next_module, false)
-    last_module.const_get(next_module, false)
-  end
-end
-
-# 'spec_overrides' from sync.yml will appear below this line

--- a/spec/unit/has_dellperc_spec.rb
+++ b/spec/unit/has_dellperc_spec.rb
@@ -7,54 +7,58 @@ describe 'has_dellperc', type: :fact do
 
   before(:each) { Facter.clear }
 
-  context 'when on linux' do
-    context 'when on physical hardware' do
-      context 'when lspci not in path' do
+  on_supported_os.each do |os, facts|
+    let(:facts) { facts }
+
+    context "on #{os}" do
+      context 'when on physical hardware' do
+        context 'when lspci not in path' do
+          it do
+            allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
+            allow(Facter.fact(:is_virtual)).to receive(:value).and_return(false)
+            allow(Facter::Util::Resolution).to receive(:exec).with('which lspci').and_return(nil)
+
+            expect(fact.value).to be_nil
+          end
+        end
+
+        context 'when lspci output does not match' do
+          it do
+            allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
+            allow(Facter.fact(:is_virtual)).to receive(:value).and_return(false)
+            allow(Facter::Util::Resolution).to receive(:exec).with('which lspci').and_return('/usr/sbin/lspci')
+            allow(Facter::Util::Resolution).to receive(:exec).with('/usr/sbin/lspci -v') do
+              File.read(fixtures('facts', 'lspci_no_match'))
+            end
+
+            expect(fact.value).to be false
+          end
+        end
+
+        context 'when lspci output does match' do
+          it do
+            allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
+            allow(Facter.fact(:is_virtual)).to receive(:value).and_return(false)
+            allow(Facter::Util::Resolution).to receive(:exec).with('which lspci').and_return('/usr/sbin/lspci')
+            allow(Facter::Util::Resolution).to receive(:exec).with('/usr/sbin/lspci -v') do
+              File.read(fixtures('facts', 'lspci_match'))
+            end
+
+            expect(fact.value).to be true
+          end
+        end
+      end
+
+      context 'when on virtual hardware' do
         it do
           allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
-          allow(Facter.fact(:is_virtual)).to receive(:value).and_return(false)
-          allow(Facter::Util::Resolution).to receive(:exec).with('which lspci').and_return(nil)
+          allow(Facter.fact(:is_virtual)).to receive(:value).and_return(true)
 
           expect(fact.value).to be_nil
         end
       end
-
-      context 'when lspci output does not match' do
-        it do
-          allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
-          allow(Facter.fact(:is_virtual)).to receive(:value).and_return(false)
-          allow(Facter::Util::Resolution).to receive(:exec).with('which lspci').and_return('/usr/sbin/lspci')
-          allow(Facter::Util::Resolution).to receive(:exec).with('/usr/sbin/lspci -v') do
-            File.read(fixtures('facts', 'lspci_no_match'))
-          end
-
-          expect(fact.value).to be false
-        end
-      end
-
-      context 'when lspci output does match' do
-        it do
-          allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
-          allow(Facter.fact(:is_virtual)).to receive(:value).and_return(false)
-          allow(Facter::Util::Resolution).to receive(:exec).with('which lspci').and_return('/usr/sbin/lspci')
-          allow(Facter::Util::Resolution).to receive(:exec).with('/usr/sbin/lspci -v') do
-            File.read(fixtures('facts', 'lspci_match'))
-          end
-
-          expect(fact.value).to be true
-        end
-      end
-    end
-
-    context 'when on virtual hardware' do
-      it do
-        allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
-        allow(Facter.fact(:is_virtual)).to receive(:value).and_return(true)
-
-        expect(fact.value).to be_nil
-      end
-    end
-  end # on linux
+    end # context "on #{os}"
+  end # on_supported_os
 
   context 'when not on linux' do
     it do

--- a/spec/unit/has_dellperc_spec.rb
+++ b/spec/unit/has_dellperc_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'has_dellperc', type: :fact do
@@ -5,65 +7,61 @@ describe 'has_dellperc', type: :fact do
 
   before(:each) { Facter.clear }
 
-  context 'on linux' do
-    context 'on physical hardware' do
-      context 'lspci not in path' do
+  context 'when on linux' do
+    context 'when on physical hardware' do
+      context 'when lspci not in path' do
         it do
-          allow(Facter.fact(:kernel)).to receive(:value) { 'Linux' }
-          allow(Facter.fact(:is_virtual)).to receive(:value) { false }
-          allow(Facter::Util::Resolution).to receive(:exec).with('which lspci') { nil }
+          allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
+          allow(Facter.fact(:is_virtual)).to receive(:value).and_return(false)
+          allow(Facter::Util::Resolution).to receive(:exec).with('which lspci').and_return(nil)
 
-          expect(subject.value).to be_nil
+          expect(fact.value).to be_nil
         end
       end
 
-      context 'lspci output does not match' do
+      context 'when lspci output does not match' do
         it do
-          allow(Facter.fact(:kernel)).to receive(:value) { 'Linux' }
-          allow(Facter.fact(:is_virtual)).to receive(:value) { false }
-          allow(Facter::Util::Resolution).to receive(:exec).with('which lspci') do
-            '/usr/sbin/lspci'
-          end
+          allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
+          allow(Facter.fact(:is_virtual)).to receive(:value).and_return(false)
+          allow(Facter::Util::Resolution).to receive(:exec).with('which lspci').and_return('/usr/sbin/lspci')
           allow(Facter::Util::Resolution).to receive(:exec).with('/usr/sbin/lspci -v') do
             File.read(fixtures('facts', 'lspci_no_match'))
           end
 
-          expect(subject.value).to eq false
+          expect(fact.value).to be false
         end
       end
 
-      context 'lspci output does match' do
+      context 'when lspci output does match' do
         it do
-          allow(Facter.fact(:kernel)).to receive(:value) { 'Linux' }
-          allow(Facter.fact(:is_virtual)).to receive(:value) { false }
-          allow(Facter::Util::Resolution).to receive(:exec).with('which lspci') do
-            '/usr/sbin/lspci'
-          end
+          allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
+          allow(Facter.fact(:is_virtual)).to receive(:value).and_return(false)
+          allow(Facter::Util::Resolution).to receive(:exec).with('which lspci').and_return('/usr/sbin/lspci')
           allow(Facter::Util::Resolution).to receive(:exec).with('/usr/sbin/lspci -v') do
             File.read(fixtures('facts', 'lspci_match'))
           end
 
-          expect(subject.value).to eq true
+          expect(fact.value).to be true
         end
       end
     end
 
-    context 'on virtual hardware' do
+    context 'when on virtual hardware' do
       it do
-        allow(Facter.fact(:kernel)).to receive(:value) { 'Linux' }
-        allow(Facter.fact(:is_virtual)).to receive(:value) { true }
+        allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
+        allow(Facter.fact(:is_virtual)).to receive(:value).and_return(true)
 
-        expect(subject.value).to be_nil
+        expect(fact.value).to be_nil
       end
     end
   end # on linux
 
-  context 'not on linux' do
+  context 'when not on linux' do
     it do
-      allow(Facter.fact(:kernel)).to receive(:value) { 'Solaris' }
-      allow(Facter.fact(:is_virtual)).to receive(:value) { false }
+      allow(Facter.fact(:kernel)).to receive(:value).and_return('Solaris')
+      allow(Facter.fact(:is_virtual)).to receive(:value).and_return(false)
 
-      expect(subject.value).to be_nil
+      expect(fact.value).to be_nil
     end
   end # not on linux
 end


### PR DESCRIPTION
This support should be considered preliminary as this fact is only useful on physical hardware with a Dell RAID controller installed.  In order to be confident that this fact is working on EL8, test fixtures for the output of `lspci` need to be copied from physical systems both with and without a Dell RAID controller installed.

Summary of changes:
- update module plumbing to ~voxpupuli 5.1.0 standard
- run unit tests on all `metadata.json` support platforms -- this doesn't add much value as this fact doesn't currently depend on any other facts
- add full set of EL8 platforms to `metadata.json`